### PR TITLE
Add security headers to Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,36 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://*.firebaseio.com https://*.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://firestore.googleapis.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
The vercel.json configuration lacks security headers. No Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, or other security headers are configured, leaving the application vulnerable to clickjacking and other client-side attacks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a restrictive `Content-Security-Policy` and other global security headers; misconfiguration could break scripts/network calls or embedding behavior in production.
> 
> **Overview**
> Adds a global `headers` block in `vercel.json` applying security headers to all paths, including `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`, and a `Content-Security-Policy` tuned for Firebase/Google APIs.
> 
> Keeps existing SPA rewrite behavior unchanged while enforcing stricter browser security defaults across the deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79178c122db72ba6cf67e75e95a1ff71dfd7cb7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->